### PR TITLE
feat: increase concurrency in controllers, make sqlite datastore default

### DIFF
--- a/api/v1alpha1/uffizzicluster_types.go
+++ b/api/v1alpha1/uffizzicluster_types.go
@@ -152,7 +152,7 @@ type UffizziClusterSpec struct {
 	ResourceQuota *UffizziClusterResourceQuota `json:"resourceQuota,omitempty"`
 	LimitRange    *UffizziClusterLimitRange    `json:"limitRange,omitempty"`
 	Sleep         bool                         `json:"sleep,omitempty"`
-	//+kubebuilder:default:="etcd"
+	//+kubebuilder:default:="sqlite"
 	//+kubebuilder:validation:Enum=etcd;sqlite
 	ExternalDatastore string `json:"externalDatastore,omitempty"`
 }

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -17,7 +17,7 @@ dependencies:
     version: 2.x.x
   - name: flux
     repository: https://charts.bitnami.com/bitnami
-    version: 0.3.x
+    version: 0.x.x
 #  - name: ingress-nginx
 #    version: 4.x.x
 #    repository: https://kubernetes.github.io/ingress-nginx

--- a/chart/templates/uffizziclusters.uffizzi.com_customresourcedefinition.yaml
+++ b/chart/templates/uffizziclusters.uffizzi.com_customresourcedefinition.yaml
@@ -66,7 +66,7 @@ spec:
                 - k8s
                 type: string
               externalDatastore:
-                default: etcd
+                default: sqlite
                 enum:
                 - etcd
                 - sqlite

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -11,6 +11,13 @@ flux:
     enabled: true
     metrics:
       enabled: false
+    args:
+      - --watch-all-namespaces
+      - --log-level=info
+      - --metrics-addr=:8080
+      - --health-addr=:9440
+      - --log-encoding=json
+      - --enable-leader-election
   sourceController:
     enabled: true
     metrics:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -18,6 +18,7 @@ flux:
       - --health-addr=:9440
       - --log-encoding=json
       - --enable-leader-election
+      - --concurrent=20
   sourceController:
     enabled: true
     metrics:

--- a/config/crd/bases/uffizzi.com_uffizziclusters.yaml
+++ b/config/crd/bases/uffizzi.com_uffizziclusters.yaml
@@ -71,7 +71,7 @@ spec:
                 - k8s
                 type: string
               externalDatastore:
-                default: etcd
+                default: sqlite
                 enum:
                 - etcd
                 - sqlite

--- a/controllers/helm/build/vcluster/build.go
+++ b/controllers/helm/build/vcluster/build.go
@@ -18,7 +18,7 @@ func BuildK3SHelmValues(uCluster *v1alpha1.UffizziCluster) (vcluster.K3S, string
 		Common:   common(helmReleaseName, vclusterIngressHostname),
 	}
 
-	if uCluster.Spec.ExternalDatastore == constants.ETCD || uCluster.Spec.ExternalDatastore == "" {
+	if uCluster.Spec.ExternalDatastore == constants.ETCD {
 		vclusterK3sHelmValues.VCluster.Env = []vcluster.ContainerEnv{
 			{
 				Name:  constants.K3S_DATASTORE_ENDPOINT,

--- a/main.go
+++ b/main.go
@@ -59,10 +59,10 @@ func init() {
 
 func main() {
 	var (
-		metricsAddr          string
-		probeAddr            string
-		enableLeaderElection bool
-		concurrent           int
+		metricsAddr               string
+		probeAddr                 string
+		enableLeaderElection      bool
+		concurrentReconciliations int
 	)
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
@@ -70,7 +70,7 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	flag.IntVar(&concurrent, "concurrent", 5, "The number of concurrent reconciles per controller.")
+	flag.IntVar(&concurrentReconciliations, "concurrent", 5, "The number of concurrent reconciles per controller.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -88,7 +88,7 @@ func main() {
 		LeaderElectionID:       "bfbf93f2.uffizzi.com",
 		Controller: ctrlcfg.ControllerConfigurationSpec{
 			GroupKindConcurrency: map[string]int{
-				uclusteruffizzicomv1alpha1.SchemaGroupVersion.WithKind("UffizziCluster").String(): concurrent,
+				uclusteruffizzicomv1alpha1.SchemaGroupVersion.WithKind("UffizziCluster").GroupKind().String(): concurrentReconciliations,
 			},
 			RecoverPanic: pointer.Bool(true),
 		},

--- a/main.go
+++ b/main.go
@@ -20,7 +20,9 @@ import (
 	"flag"
 	etcd "github.com/UffizziCloud/uffizzi-cluster-operator/controllers/etcd"
 	"github.com/UffizziCloud/uffizzi-cluster-operator/controllers/uffizzicluster"
+	"k8s.io/utils/pointer"
 	"os"
+	ctrlcfg "sigs.k8s.io/controller-runtime/pkg/config/v1alpha1"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
@@ -56,14 +58,19 @@ func init() {
 }
 
 func main() {
-	var metricsAddr string
-	var enableLeaderElection bool
-	var probeAddr string
+	var (
+		metricsAddr          string
+		probeAddr            string
+		enableLeaderElection bool
+		concurrent           int
+	)
+
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
+	flag.IntVar(&concurrent, "concurrent", 5, "The number of concurrent reconciles per controller.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -79,17 +86,12 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         enableLeaderElection,
 		LeaderElectionID:       "bfbf93f2.uffizzi.com",
-		// LeaderElectionReleaseOnCancel defines if the leader should step down voluntarily
-		// when the Manager ends. This requires the binary to immediately end when the
-		// Manager is stopped, otherwise, this setting is unsafe. Setting this significantly
-		// speeds up voluntary leader transitions as the new leader don't have to wait
-		// LeaseDuration time first.
-		//
-		// In the default scaffold provided, the program ends immediately after
-		// the manager stops, so would be fine to enable this option. However,
-		// if you are doing or is intended to do any operation such as perform cleanups
-		// after the manager stops then its usage might be unsafe.
-		// LeaderElectionReleaseOnCancel: true,
+		Controller: ctrlcfg.ControllerConfigurationSpec{
+			GroupKindConcurrency: map[string]int{
+				uclusteruffizzicomv1alpha1.SchemaGroupVersion.WithKind("UffizziCluster").String(): concurrent,
+			},
+			RecoverPanic: pointer.Bool(true),
+		},
 	})
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
@@ -108,7 +110,7 @@ func main() {
 		Client: mgr.GetClient(),
 		Scheme: mgr.GetScheme(),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "UffizziCluster")
+		setupLog.Error(err, "unable to create controller", "controller", "UffizziClusterEtcd")
 		os.Exit(1)
 	}
 	//+kubebuilder:scaffold:builder


### PR DESCRIPTION
- update concurrent reconciliations for the helm controller from 5 to 20
- cleanup some of the main.go 
- update date concurrent reconciliations for the uffizzicluster controller from 1 to 5
- sqlite as the default externalDatastore

Note the worker count in the uffizzicluster controller before and after. The default number of workers has been set to 5.

Updated uffizzi cluster worker count 
```
2023-11-22T11:19:53Z    DEBUG   events  pr-79-uffizzi-cluster-operator-5fcc7bd77b-52zt8_e5592983-09ee-42e1-9731-a87930fbb1cb became leader    {"type": "Normal", "object": {"kind":"Lease","namespace":"default","name":"bfbf93f2.uffizzi.com","uid":"1d6999de-703d-435a-9f87-39220da52312","apiVersion":"coordination.k8s.io/v1","resourceVersion":"1230"}, "reason": "LeaderElection"}
2023-11-22T11:19:53Z    INFO    Starting workers        {"controller": "uffizzicluster", "controllerGroup": "uffizzi.com", "controllerKind": "UffizziCluster", "worker count": 5}
2023-11-22T11:19:53Z    INFO    Starting workers        {"controller": "uffizzicluster", "controllerGroup": "uffizzi.com", "controllerKind": "UffizziCluster", "worker count": 5}
```

Updated helm controller worker count
```
{"level":"info","ts":"2023-11-22T11:09:26.904Z","msg":"Starting Controller","controller":"helmrelease","controllerGroup":"helm.toolkit.fluxcd.io","controllerKind":"HelmRelease"}
{"level":"info","ts":"2023-11-22T11:09:27.008Z","msg":"Starting workers","controller":"helmrelease","controllerGroup":"helm.toolkit.fluxcd.io","controllerKind":"HelmRelease","worker count":20}
```

fixes #77 #78 